### PR TITLE
Rename singleItemInCart constraint to oneOrderInCart. Fix it to properly enforce one Order can be in the "cart" status. Minimize the syntax used. Use an index to look up orders by customer by status

### DIFF
--- a/server/schema/collections.fsl
+++ b/server/schema/collections.fsl
@@ -67,7 +67,7 @@ collection Order {
   }))
   payment: { *: Any }
 
-  check singleItemInCart (order => {
+  check oneOrderInCart (order => {
     Order.byCustomerAndStatus(order.customer, "cart").count() <= 1
   })
 


### PR DESCRIPTION
# Problem / Solution

- use an index to get cart order
- fix single order in cart constraint
- use minimal syntax
# Testing

- pushed the schema
- created a customer
- created an order