### PR TITLE
Add setup to README update package.json to properly start server

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -1,5 +1,6 @@
 ## Setting up your project
 
+### Create a Database
 To setup your project you first need to create a database.
 
 Do this by first creating a credential for the fauna shell your account using:
@@ -18,6 +19,8 @@ fauna create-database E_Commerce
 
 to create the database we will use for the E-Commerce application we're building.
 
+### Push the schema
+
 Now you've got the database we'll use. At this point we'll push our schema by running:
 
 ```
@@ -27,10 +30,27 @@ fauna schema push
 This will use the `.fauna-project` file to push the files in the `/schema` directory.
 
 
+## Set environmental variables for your server
 
-## To Start
+Create a secret via the command:
+
+```sh
+fauna create-key E_Commerce admin
+```
+
+This will print out a secret.
+
+Copy `.env.example` into a local `.env` file. Replace the secret with the secret you just created.
+
+## To Start the Server
 
 - run `npm install && npm run dev`.
+
+This will start a nodemon server that will listen for local changes and auto deploy them.
+
+## To Test
+
+To test, first start the server. Then in another buffer run `npm run test`.
 
 ## To Build
 

--- a/server/package.json
+++ b/server/package.json
@@ -7,7 +7,7 @@
     "build": "tsc",
     "test": "jest",
     "dev": "nodemon src/index.ts",
-    "start": "node build/index.js"
+    "start": "build; node build/src/index.js"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
README needs instructions to create a key and get it where the app can use it.

The `npm run start` command was broken because it was looking in wrong place for the server.