### PR TITLE
[DOCS-3175] Improve 401 error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ following curl request to the `POST /customers` endpoint. The request creates a
 `Customer` collection document in the `ECommerce` database.
 
 ```
-curl -X POST \
+curl -v \
   http://localhost:8000/customers \
   -H "Content-Type: application/json" \
   -d '{

--- a/server/src/middleware/errors.ts
+++ b/server/src/middleware/errors.ts
@@ -1,0 +1,24 @@
+import { Request, Response, NextFunction } from "express";
+import { ServiceError } from "fauna";
+
+// Middleware to handle 401 errors
+export const errorHandler = (
+  err: any,
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  if (err instanceof ServiceError) {
+    if (err.code === "unauthorized") {
+      // If unauthorized, return an error instructing the admin to check
+      // the `FAUNA_SECRET` env var.
+      return res.status(401).send({
+        message:
+          "Unauthorized. Set the `FAUNA_SECRET` env var to a valid Fauna key's secret.",
+      });
+    } else {
+      // Return a generic 500 if we encounter an unexpected error.
+      return res.status(500).send({ message: "Internal Server Error" });
+    }
+  }
+};


### PR DESCRIPTION
### Problem
Several users have gotten a generic 500 error after failing to properly set the `FAUNA_SECRET` env var.

### Solution
Adds some error handling middleware to return a 401 error if Fauna returns an `unauthorized` error code. The middleware can be expanded to handle other types of errors in the future.


Rel: https://faunadb.atlassian.net/browse/DOCS-3175