### PR TITLE
[DOCS-3215] Add tutorial for expanding app

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ docs](https://docs.fauna.com/fauna/current/tools/shell/).
     - `ECommerce` is the default database for the project.
 
     - The project stores Fauna Schema Language (FSL) files in the
-      `schema/` directory.
+      `schema` directory.
 
 1. Log in to Fauna using the Fauna CLI:
 
@@ -116,7 +116,7 @@ docs](https://docs.fauna.com/fauna/current/tools/shell/).
     fauna create-database --environment='' ECommerce
     ```
 
-1.  Push the FSL files in the `schema/` directory to the `ECommerce`
+1.  Push the FSL files in the `schema` directory to the `ECommerce`
     database:
 
     ```sh
@@ -125,7 +125,7 @@ docs](https://docs.fauna.com/fauna/current/tools/shell/).
 
     When prompted, accept and push the changes. The push creates the collections
     and user-defined functions (UDFs) defined in the FSL files of the
-    `schema/` directory.
+    `schema` directory.
 
 1. Create a key with the `server` role for the `ECommerce` database:
 
@@ -180,7 +180,7 @@ Once started, the local server is available at http://localhost:8000.
 ## HTTP API endpoints
 
 The app's HTTP API endpoints are defined in `*.controller.ts` files in the
-`src/routes/` directory.
+`src/routes` directory.
 
 Reference documentation for the endpoints is available at
 https://fauna.github.io/js-sample-app/.
@@ -216,7 +216,7 @@ You can further expand the app by adding fields and endpoints.
 As an example, the following steps adds a computed `totalPurchaseAmt` field to
 Customer documents and related API responses:
 
-1. If you haven't already, [add the sample data](#add-sample-data):
+1. If you haven't already, add the sample data:
 
     ```sh
     npm install && npm run test

--- a/README.md
+++ b/README.md
@@ -225,18 +225,18 @@ Customer documents and related API responses:
 1. In `schema/collections.fsl`, add the following `totalPurchaseAmt` computed
   field definition to the `Customer` collection:
 
-    ```fsl
+    ```diff
     collection Customer {
       ...
       // Use a computed field to get the set of Orders for a customer.
       compute orders: Set<Order> = (customer => Order.byCustomer(customer))
 
-      // Use a computed field to calculate the customer's cumulative purchase total.
-      // The field sums purchase `total` values from the customer's linked Order documents.
-      compute totalPurchaseAmt: Number = (customer => customer.orders.fold(0, (sum, order) => {
-        let order: Any = order
-        sum + order.total
-      }))
+    + // Use a computed field to calculate the customer's cumulative purchase total.
+    + // The field sums purchase `total` values from the customer's linked Order documents.
+    + compute totalPurchaseAmt: Number = (customer => customer.orders.fold(0, (sum, order) => {
+    +   let order: Any = order
+    +   sum + order.total
+    + }))
       ...
     }
     ...
@@ -253,14 +253,14 @@ Customer documents and related API responses:
 1. In `src/routes/customers/customers.controller.ts`, add the
    `totalPurchaseAmt` field to the `customerResponse` FQL template:
 
-    ```js
+    ```diff
     // Project Customer document fields for consistent responses.
     const customerResponse = fql`
       customer {
         id,
         name,
         email,
-        totalPurchaseAmt,
+    +   totalPurchaseAmt,
         address
       }
     `;

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ docs](https://docs.fauna.com/fauna/current/tools/shell/).
     - The project stores Fauna Schema Language (FSL) files in the
       `schema` directory.
 
-1. Log in to Fauna using the Fauna CLI:
+2. Log in to Fauna using the Fauna CLI:
 
     ```sh
     fauna cloud-login
@@ -110,13 +110,13 @@ docs](https://docs.fauna.com/fauna/current/tools/shell/).
     [Forgot Password](https://dashboard.fauna.com/forgot-password) workflow.
 
 
-1. Use the Fauna CLI to create the `ECommerce` database:
+3. Use the Fauna CLI to create the `ECommerce` database:
 
     ```sh
     fauna create-database --environment='' ECommerce
     ```
 
-1.  Push the FSL files in the `schema` directory to the `ECommerce`
+4.  Push the FSL files in the `schema` directory to the `ECommerce`
     database:
 
     ```sh
@@ -127,7 +127,7 @@ docs](https://docs.fauna.com/fauna/current/tools/shell/).
     and user-defined functions (UDFs) defined in the FSL files of the
     `schema` directory.
 
-1. Create a key with the `server` role for the `ECommerce` database:
+5. Create a key with the `server` role for the `ECommerce` database:
 
     ```sh
     fauna create-key --environment='' ECommerce server
@@ -136,13 +136,13 @@ docs](https://docs.fauna.com/fauna/current/tools/shell/).
     Copy the returned `secret`. The app can use the key's secret to authenticate
     requests to the database.
 
-1. Make a copy of the `.env.example` file and name the copy `.env`. For example:
+6. Make a copy of the `.env.example` file and name the copy `.env`. For example:
 
     ```sh
     cp .env.example .env
     ```
 
-1.  In `.env`, set the `FAUNA_SECRET` environment variable to the secret you
+7.  In `.env`, set the `FAUNA_SECRET` environment variable to the secret you
     copied earlier:
 
     ```
@@ -222,7 +222,7 @@ Customer documents and related API responses:
     npm install && npm run test
     ```
 
-1. In `schema/collections.fsl`, add the following `totalPurchaseAmt` computed
+2. In `schema/collections.fsl`, add the following `totalPurchaseAmt` computed
   field definition to the `Customer` collection:
 
     ```diff
@@ -244,13 +244,13 @@ Customer documents and related API responses:
 
     Save `schema/collections.fsl`.
 
-1.  Push the updated schema to the `ECommerce` database:
+3.  Push the updated schema to the `ECommerce` database:
 
     ```sh
     fauna schema push
     ```
 
-1. In `src/routes/customers/customers.controller.ts`, add the
+4. In `src/routes/customers/customers.controller.ts`, add the
    `totalPurchaseAmt` field to the `customerResponse` FQL template:
 
     ```diff
@@ -271,13 +271,13 @@ Customer documents and related API responses:
    Customer-related endpoints use this template to project Customer
    document fields in responses.
 
-1. Start the app server:
+5. Start the app server:
 
     ```sh
     npm install && npm run dev
     ```
 
-1. With the local server running in a separate terminal tab, run the
+6. With the local server running in a separate terminal tab, run the
    following curl request to the `POST /customers` endpoint:
 
     ```sh

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ docs](https://docs.fauna.com/fauna/current/tools/shell/).
     - `ECommerce` is the default database for the project.
 
     - The project stores Fauna Schema Language (FSL) files in the
-      `/schema` directory.
+      `schema/` directory.
 
 1. Log in to Fauna using the Fauna CLI:
 
@@ -116,7 +116,7 @@ docs](https://docs.fauna.com/fauna/current/tools/shell/).
     fauna create-database --environment='' ECommerce
     ```
 
-1.  Push the FSL files in the `/schema` directory to the `ECommerce`
+1.  Push the FSL files in the `schema/` directory to the `ECommerce`
     database:
 
     ```sh
@@ -125,7 +125,7 @@ docs](https://docs.fauna.com/fauna/current/tools/shell/).
 
     When prompted, accept and push the changes. The push creates the collections
     and user-defined functions (UDFs) defined in the FSL files of the
-    `/schema` directory.
+    `schema/` directory.
 
 1. Create a key with the `server` role for the `ECommerce` database:
 
@@ -180,7 +180,7 @@ Once started, the local server is available at http://localhost:8000.
 ## HTTP API endpoints
 
 The app's HTTP API endpoints are defined in `*.controller.ts` files in the
-`/src/routes` directory.
+`src/routes/` directory.
 
 Reference documentation for the endpoints is available at
 https://fauna.github.io/js-sample-app/.
@@ -192,22 +192,112 @@ You can use the endpoints to make API requests that read and write data from
 the `ECommerce` database.
 
 For example, with the local server running in a separate terminal tab, run the
-following curl request to the `POST /customers` endpoint. The request creates a
-`Customer` collection document in the `ECommerce` database.
+following curl request to the `POST /products` endpoint. The request creates a
+`Product` collection document in the `ECommerce` database.
 
-```
+```sh
 curl -v \
-  http://localhost:8000/customers \
+  http://localhost:8000/products \
   -H "Content-Type: application/json" \
   -d '{
-    "name": "John Doe",
-    "email": "john.doe@example.com",
-    "address": {
-      "street": "123 Main St",
-      "city": "San Francisco",
-      "state": "CA",
-      "postalCode": "12345",
-      "country": "USA"
-    }
+    "name": "The Old Man and the Sea",
+    "price": 899,
+    "description": "A book by Ernest Hemingway",
+    "stock": 10,
+    "category": "books"
   }'
 ```
+
+
+## Expand the app
+
+You can further expand the app by adding fields and endpoints.
+
+As an example, the following steps adds a computed `totalPurchaseAmt` field to
+Customer documents and related API responses:
+
+1. If you haven't already, [add the sample data](#add-sample-data):
+
+    ```sh
+    npm install && npm run test
+    ```
+
+1. In `schema/collections.fsl`, add the following `totalPurchaseAmt` computed
+  field definition to the `Customer` collection:
+
+    ```fsl
+    collection Customer {
+      ...
+      // Use a computed field to get the set of Orders for a customer.
+      compute orders: Set<Order> = (customer => Order.byCustomer(customer))
+
+      // Use a computed field to calculate the customer's cumulative purchase total.
+      // The field sums purchase `total` values from the customer's linked Order documents.
+      compute totalPurchaseAmt: Number = (customer => customer.orders.fold(0, (sum, order) => {
+        let order: Any = order
+        sum + order.total
+      }))
+      ...
+    }
+    ...
+    ```
+
+    Save `schema/collections.fsl`.
+
+1.  Push the updated schema to the `ECommerce` database:
+
+    ```sh
+    fauna schema push
+    ```
+
+1. In `src/routes/customers/customers.controller.ts`, add the
+   `totalPurchaseAmt` field to the `customerResponse` FQL template:
+
+    ```js
+    // Project Customer document fields for consistent responses.
+    const customerResponse = fql`
+      customer {
+        id,
+        name,
+        email,
+        totalPurchaseAmt,
+        address
+      }
+    `;
+    ```
+
+    Save `src/routes/customers/customers.controller.ts`.
+
+   Customer-related endpoints use this template to project Customer
+   document fields in responses.
+
+1. Start the app server:
+
+    ```sh
+    npm install && npm run dev
+    ```
+
+1. With the local server running in a separate terminal tab, run the
+   following curl request to the `POST /customers` endpoint:
+
+    ```sh
+    curl -v http://localhost:8000/customers/999
+    ```
+
+    The response includes the computed `totalPurchaseAmt` field:
+
+    ```json
+    {
+      "id": "999",
+      "name": "Valued Customer",
+      "email": "valuedcustomer@fauna.com",
+      "totalPurchaseAmt": 27000,
+      "address": {
+        "street": "123 Main St",
+        "city": "San Francisco",
+        "state": "CA",
+        "postalCode": "12345",
+        "country": "United States"
+      }
+    }
+    ```

--- a/__tests__/mocks.ts
+++ b/__tests__/mocks.ts
@@ -17,6 +17,7 @@ export const mockAddr = (overrides?: {
 };
 
 export const mockCustomer = (overrides?: {
+  id?: string;
   name?: string;
   email?: string;
   address?: {
@@ -29,6 +30,7 @@ export const mockCustomer = (overrides?: {
 }) => {
   const fakeName = faker.internet.userName();
   return {
+    ...(overrides?.id && { id: overrides.id }),
     name: overrides?.name || fakeName,
     email:
       overrides?.email ||

--- a/__tests__/seed.ts
+++ b/__tests__/seed.ts
@@ -119,7 +119,7 @@ export const seedTestData = async () => {
   await Promise.all(productCreates);
 
   // Create a customer.
-  const c = mockCustomer({ name: "Valued Customer" });
+  const c = mockCustomer({ id: "999", name: "Valued Customer" });
   const customer = (
     await faunaClient.query<Customer>(
       fql`Customer.byEmail(${c.email}).first() ?? Customer.create(${c})`
@@ -145,7 +145,7 @@ export const seedTestData = async () => {
             customer: Customer.byId(${customer.id}),
             payment: {}
           })
-          let product: Any = Product.all().first()!
+          let product: Any = Product.byName("Drone").first()!
           OrderItem.create({ order: newOrder, product: product, quantity: 1 })
           newOrder
         } else {

--- a/src/routes/customers/customers.controller.ts
+++ b/src/routes/customers/customers.controller.ts
@@ -11,6 +11,16 @@ import { errorHandler } from "../../middleware/errors";
 
 const router = Router();
 
+// Project Customer document fields for consistent responses.
+const customerResponse = fql`
+  customer {
+    id,
+    name,
+    email,
+    address
+  }
+`;
+
 /**
  * Get a customer by id.
  * @route {GET} /customers/:id
@@ -33,12 +43,9 @@ router.get(
         // If the document does not exist, Fauna will throw a document_not_found error.
         // Use projection to only return the fields you need.
         fql`let customer: Any = Customer.byId(${id})!
-          customer {
-            id,
-            name,
-            email,
-            address
-          }`
+          // Return projected fields for the response.
+          ${customerResponse}
+        `
       );
 
       // Return the customer, stripping out any unnecessary fields.
@@ -89,12 +96,9 @@ router.post(
         // Create a new Customer document with the provided fields.
         // Use projection to only return the fields you need.
         fql`let customer: Any = Customer.create(${{ name, email, address }})
-          customer {
-            id,
-            name,
-            email,
-            address
-          }`
+          // Return projected fields for the response.
+          ${customerResponse}
+        `
       );
 
       // Return the created customer, stripping out any unnecessary fields.
@@ -151,12 +155,9 @@ router.patch(
         // If the document does not exist, Fauna will throw a document_not_found error.
         // Use projection to only return the fields you need.
         fql`let customer: Any = Customer.byId(${id})!.update(${{ name, email, address }})
-          customer {
-            id,
-            name,
-            email,
-            address
-          }`
+          // Return projected fields for the response.
+          ${customerResponse}
+        `
       );
 
       // Return the updated customer, stripping out any unnecessary fields.


### PR DESCRIPTION
### Problem

We've received some feedback that users would like a short tutorial that showcases how they could update the app.

### Solution

- Adds a short tutorial to the README.
- Update the seed data to use a consistent user ID and product.
- Update the customer controller so it's easier to update response fields.