### PR TITLE
Schema: Remove commas from nested fields

### DIFF
--- a/schema/collections.fsl
+++ b/schema/collections.fsl
@@ -2,10 +2,10 @@ collection Customer {
   name: String
   email: String
   address: {
-    street: String,
-    city: String,
-    state: String,
-    postalCode: String,
+    street: String
+    city: String
+    state: String
+    postalCode: String
     country: String
   }
 


### PR DESCRIPTION
Comma delimiters are no longer required for nested fields.