### PR TITLE
[DOCS-3367] Remove `id` and `order` from OrderItems model

### DIFF
--- a/src/routes/orders/orders.model.ts
+++ b/src/routes/orders/orders.model.ts
@@ -12,8 +12,6 @@ export interface Order extends QueryValueObject {
 }
 
 export interface OrderItem extends QueryValueObject {
-  id: string;
-  order: Order;
   product: Product;
   quantity: number;
 }


### PR DESCRIPTION
### Problem

I removed the `id` and `id` fields for order items from order responses in https://github.com/fauna/js-sample-app/pull/43. I didn't remove them from the model.

### Solution

Clean up the model.