### PR TITLE
[DOCS-3368] Fix title for JS sample app API ref

### DIFF
--- a/.redocly.lint-ignore.yaml
+++ b/.redocly.lint-ignore.yaml
@@ -1,0 +1,7 @@
+# This file instructs Redocly's linter to ignore the rules contained for specific parts of your API.
+# See https://redoc.ly/docs/cli/ for more information.
+openapi.yml:
+  spec:
+    - '#/info'
+  info-license:
+    - '#/info'

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Redoc</title>
+    <title>HTTP API reference - Fauna JavaScript sample app</title>
     <!-- needed for adaptive design -->
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/openapi.yml
+++ b/openapi.yml
@@ -1,10 +1,6 @@
 openapi: 3.0.3
 info:
   title: Fauna JavaScript sample app
-  version: 1.0.0
-  license:
-    name: Fauna terms
-    url: "https://fauna.com/terms"
   description: |
     HTTP API reference documentation for the [Fauna JavaScript sample
     app](https://github.com/fauna/js-sample-app).


### PR DESCRIPTION
- Updates the `<title>` for the sample app's API reference. It's currently "Redoc."
- Removes licensing info from the API reference.
- Adds a related ignore file to ignore linting errors related to the missing licensing info.