### PR TITLE
docs: README: Bump CLI v4 Node vers

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ To run the app, you'll need:
 3. Use the CLI to create the `ECommerce` database:
 
     ```sh
-    # Replace 'us' with your preferred Region Group:
+    # Replace 'us' with your preferred region group:
     # 'us' (United States), 'eu' (Europe), or `global`.
     fauna database create \
       --name ECommerce \
@@ -105,7 +105,7 @@ To run the app, you'll need:
     database:
 
     ```sh
-    # Replace 'us' with your Region Group.
+    # Replace 'us' with your region group.
     fauna schema push \
       --database us/ECommerce
     ```

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ To run the app, you'll need:
 - A [Fauna account](https://dashboard.fauna.com/register). You can sign up for a
   free account at https://dashboard.fauna.com/register.
 
-- [Node.js](https://nodejs.org/en/download/) v20.x or later.
+- [Node.js](https://nodejs.org/en/download/) v22.x or later.
 
 - [Fauna CLI v4](https://docs.fauna.com/fauna/current/build/cli/v4/).
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ To run the app, you'll need:
 - A [Fauna account](https://dashboard.fauna.com/register). You can sign up for a
   free account at https://dashboard.fauna.com/register.
 
-- [Node.js](https://nodejs.org/en/download/) v22.x or later.
+- [Node.js](https://nodejs.org/en/download/) v20.18 or later.
+  - [Node.js](https://nodejs.org/en/download/) v22 or later recommended.
 
 - [Fauna CLI v4](https://docs.fauna.com/fauna/current/build/cli/v4/).
 


### PR DESCRIPTION
## Problem
Two unrelated changes (bundling cause it's just README):

* Per https://github.com/fauna/fauna-shell/pull/579, we recently bumped Node versions for CLI v4:
  * Required: v20.18 or later
  * Recommended: v22 or later
* We recently aligned with marketing to use sentence case for several feature names, including "Region Group."

## Solution

Updates the README.